### PR TITLE
Add CP/CG tracking & 3D plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ python rocket_simulation/example.py
 - Monte Carlo uncertainty propagation
 - Standard atmosphere and wind modeling
 - Parallel processing for Monte Carlo simulations
-- Comprehensive visualization and analysis tools 
+- Comprehensive visualization and analysis tools
+- 3D trajectory plotting and CP/CG tracking

--- a/rocket_simulation/example.py
+++ b/rocket_simulation/example.py
@@ -51,7 +51,8 @@ def main():
     
     # Plot Monte Carlo results and get output directory
     output_dir = monte_carlo.plot_results(mc_results)
-    
+    monte_carlo.plot_trajectory_cloud_3d(mc_results, save_plots=True)
+
     # Plot single simulation results to the same directory
     plot_single_simulation(results, output_dir)
     
@@ -64,7 +65,7 @@ def plot_single_simulation(results, output_dir=None):
         output_dir = "simulation_plots"
     os.makedirs(output_dir, exist_ok=True)
     
-    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    fig, axes = plt.subplots(3, 2, figsize=(12, 14))
     
     # Altitude vs time
     axes[0, 0].plot(results['time'], results['altitude'])
@@ -96,6 +97,22 @@ def plot_single_simulation(results, output_dir=None):
     axes[1, 1].set_title('Euler Angles')
     axes[1, 1].legend()
     axes[1, 1].grid(True, alpha=0.3)
+
+    # Center of pressure and CG over time
+    axes[2, 0].plot(results['time'], results['center_of_mass'], label='CG')
+    axes[2, 0].axhline(results['cp_location'], color='r', linestyle='--', label='CP')
+    axes[2, 0].set_xlabel('Time (s)')
+    axes[2, 0].set_ylabel('Position along body (m)')
+    axes[2, 0].set_title('CP and CG vs Time')
+    axes[2, 0].legend()
+    axes[2, 0].grid(True, alpha=0.3)
+
+    # Angle of attack over time
+    axes[2, 1].plot(results['time'], np.degrees(results['angle_of_attack']))
+    axes[2, 1].set_xlabel('Time (s)')
+    axes[2, 1].set_ylabel('Angle (deg)')
+    axes[2, 1].set_title('Angle of Attack vs Time')
+    axes[2, 1].grid(True, alpha=0.3)
     
     plt.tight_layout()
     

--- a/rocket_simulation/monte_carlo.py
+++ b/rocket_simulation/monte_carlo.py
@@ -264,6 +264,11 @@ class MonteCarloAnalyzer:
             results = simulator.simulate_flight(initial_conditions, wind_profile, altitude_profile)
             results['simulation_id'] = simulation_id
             results['parameters'] = params
+            results['trajectory'] = {
+                'time': results['time'],
+                'altitude': results['altitude'],
+                'position': results['position'].T
+            }
             return results
         except Exception as e:
             print(f"Simulation {simulation_id} failed: {e}")
@@ -519,5 +524,35 @@ class MonteCarloAnalyzer:
             plot_path = os.path.join(output_dir, 'monte_carlo_trajectories.png')
             plt.savefig(plot_path, dpi=300, bbox_inches='tight')
             print(f"Trajectory plots saved to: {plot_path}")
-        
-        # plt.show() 
+
+        # plt.show()
+
+    def plot_trajectory_cloud_3d(self, analysis, save_plots=True, max_trajectories=50):
+        """Plot 3D trajectories from Monte Carlo results."""
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+        fig = plt.figure(figsize=(10, 8))
+        ax = fig.add_subplot(111, projection='3d')
+
+        trajectories = analysis['results'][:max_trajectories]
+        for result in trajectories:
+            if 'trajectory' in result and 'position' in result['trajectory']:
+                pos = result['trajectory']['position']
+                x = pos[:, 0]
+                y = pos[:, 1]
+                z = pos[:, 2]
+                ax.plot(x, y, z, alpha=0.3, linewidth=0.5)
+
+        ax.set_xlabel('East Position (m)')
+        ax.set_ylabel('North Position (m)')
+        ax.set_zlabel('Altitude (m)')
+        ax.set_title(f'3D Trajectory Cloud ({len(trajectories)} trajectories)')
+        ax.grid(True, alpha=0.3)
+
+        if save_plots:
+            output_dir = self._create_output_directory()
+            plot_path = os.path.join(output_dir, 'monte_carlo_trajectories_3d.png')
+            plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+            print(f"3D trajectory plot saved to: {plot_path}")
+
+        # plt.show()


### PR DESCRIPTION
## Summary
- track center of mass and stability margin over time
- expose trajectory data in Monte Carlo results
- add 3D trajectory cloud plotting
- show CP/CG and angle of attack in the example plots
- document new 3D and CP/CG capabilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c815c8fa8833090d7a26d6028a28d