### PR TITLE
Add launch rail phase with dynamic CP

### DIFF
--- a/rocket_simulation/example.py
+++ b/rocket_simulation/example.py
@@ -100,7 +100,7 @@ def plot_single_simulation(results, output_dir=None):
 
     # Center of pressure and CG over time
     axes[2, 0].plot(results['time'], results['center_of_mass'], label='CG')
-    axes[2, 0].axhline(results['cp_location'], color='r', linestyle='--', label='CP')
+    axes[2, 0].plot(results['time'], results['cp_location_dynamic'], '--', color='r', label='CP')
     axes[2, 0].set_xlabel('Time (s)')
     axes[2, 0].set_ylabel('Position along body (m)')
     axes[2, 0].set_title('CP and CG vs Time')


### PR DESCRIPTION
## Summary
- add Mach-based CP shift and dynamic CP calculation
- simulate a 60-ft launch rail before free flight
- track CP over time and plot it in the example

## Testing
- `python rocket_simulation/example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686c8995ae288330b3116aa6386d195d