### PR TITLE
Add rail exit diagnostic metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ initial_conditions = {
 
 # Single simulation
 results = simulator.simulate_flight(initial_conditions)
+print(f"Rail exit speed: {results['rail_exit_speed']:.1f} m/s")
 
 # Monte Carlo analysis
 monte_carlo = MonteCarloAnalyzer(rocket, motor, atmosphere, wind_model)
@@ -64,3 +65,4 @@ python rocket_simulation/example.py
 - Parallel processing for Monte Carlo simulations
 - Comprehensive visualization and analysis tools
 - 3D trajectory plotting and CP/CG tracking
+- Detailed launch metrics including rail exit speed and aerodynamic angles

--- a/rocket_simulation/example.py
+++ b/rocket_simulation/example.py
@@ -38,6 +38,11 @@ def main():
     results = simulator.simulate_flight(initial_conditions)
     
     # Print results
+    print(f"Rail exit speed: {results['rail_exit_speed']:.2f} m/s")
+    print(
+        f"Rail AoA: {np.degrees(results['rail_exit_angle_of_attack']):.2f} deg, "
+        f"sideslip: {np.degrees(results['rail_exit_sideslip']):.2f} deg"
+    )
     print(f"Apogee altitude: {results['apogee_altitude']:.1f} m ({results['apogee_altitude']*3.28084:.1f} ft)")
     print(f"Range: {results['range']:.1f} m")
     print(f"Flight time: {results['flight_time']:.1f} s")


### PR DESCRIPTION
## Summary
- compute rail exit info in flight simulator for improved debugging
- expose rail exit speed, angles, and wind in results
- print rail exit metrics in example script and README
- document feature in README

## Testing
- `python -m py_compile rocket_simulation/*.py`
- `python rocket_simulation/example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d149c7bcc8330ac5bf6e0f5368607