### PR TITLE
Implement ambient pressure dependent thrust

### DIFF
--- a/rocket_simulation/simulator.py
+++ b/rocket_simulation/simulator.py
@@ -62,7 +62,7 @@ class FlightSimulator:
             aero_coeffs = self.rocket.get_aerodynamic_coefficients(mach, 0.0)
             drag = 0.5 * density * speed ** 2 * aero_coeffs['cd'] * self.rocket.reference_area
 
-            thrust = self.motor.get_thrust(t)
+            thrust = self.motor.get_thrust(t, atm['pressure'])
             gravity = self.atmosphere.get_gravity(position[2])
             accel = (thrust - mass * gravity - drag) / mass
 
@@ -217,7 +217,7 @@ class FlightSimulator:
         moments_body = np.zeros(3)
         
         # Thrust force
-        thrust = self.motor.get_thrust(t)
+        thrust = self.motor.get_thrust(t, atm_props['pressure'])
         forces_body[0] += thrust  # Thrust along x-axis
         
         # Aerodynamic forces


### PR DESCRIPTION
## Summary
- model thrust difference between sea level and vacuum
- allow SolidMotor.get_thrust() to use ambient pressure
- adjust Monte Carlo motor perturbation
- pass ambient pressure from simulator to motor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python rocket_simulation/example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686d2143856c83309abdeb3663e284fa