### PR TITLE
Refine aerodynamic modeling

### DIFF
--- a/rocket_simulation/rocket.py
+++ b/rocket_simulation/rocket.py
@@ -19,6 +19,8 @@ class Rocket:
         self.fin_root_chord = 0.20  # Fin root chord (m)
         self.fin_tip_chord = 0.1 # Fin tip chord (m)
         self.fin_count = 4  # Number of fins
+        self.fin_sweep_angle = 0.0  # Fin leading edge sweep (rad)
+        self.fin_cant_angle = 0.0   # Fin cant angle (rad)
         
         # Mass properties (dry mass)
         self.dry_mass = 70.4  # kg (250 lb)
@@ -65,16 +67,23 @@ class Rocket:
         CN_body = 0.0
         X_body = 0.0
         
-        # Fin contribution
-        fin_area = 0.5 * (self.fin_root_chord + self.fin_tip_chord) * self.fin_span
-        fin_mid_chord = (self.fin_root_chord + self.fin_tip_chord) / 2
-        
-        CN_fins = 2 * self.fin_count * (1 + self.diameter / (2 * self.fin_span)) * \
-                  (fin_area / self.reference_area)
-        
-        X_fins = self.length - self.fin_root_chord + \
-                 (self.fin_tip_chord + 2 * self.fin_root_chord) * fin_mid_chord / \
-                 (3 * (self.fin_tip_chord + self.fin_root_chord))
+        # Fin contribution with sweep
+        cr = self.fin_root_chord
+        ct = self.fin_tip_chord
+        s = self.fin_span
+        sweep = self.fin_sweep_angle
+
+        fin_area = 0.5 * (cr + ct) * s
+        lambda_ratio = ct / cr if cr != 0 else 0.0
+
+        # Normal force slope (same as before)
+        CN_fins = 2 * self.fin_count * (1 + self.diameter / (2 * s)) * (fin_area / self.reference_area)
+
+        # Quarter-chord of mean aerodynamic chord
+        mac = (2 / 3) * cr * (1 + lambda_ratio + lambda_ratio**2) / (1 + lambda_ratio)
+        y_bar = s * (1 + 2 * lambda_ratio) / (3 * (1 + lambda_ratio))
+        x_root = self.length - cr
+        X_fins = x_root + y_bar * np.tan(sweep) + 0.25 * mac
         
         # Total center of pressure
         CN_total = CN_nose + CN_body + CN_fins
@@ -118,36 +127,52 @@ class Rocket:
             'Izz': current_Izz
         }
     
-    def get_aerodynamic_coefficients(self, mach, alpha, beta=0.0):
+    def get_aerodynamic_coefficients(self, mach, alpha, beta=0.0, mass_props=None):
         """Get aerodynamic coefficients for current flight conditions."""
         # Drag coefficient
         cd0 = interpolate_1d(mach, self.Cd_data['mach'], self.Cd_data['cd0'])
         cda = interpolate_1d(mach, self.Cd_data['mach'], self.Cd_data['cda'])
         cd = cd0 + cda * alpha**2
-        
-        # Lift coefficient (simplified model)
-        cl_alpha = 2.0  # per radian
+
+        # Lift coefficient using finite wing theory with sweep
+        cr = self.fin_root_chord
+        ct = self.fin_tip_chord
+        s = self.fin_span
+        lambda_ratio = ct / cr if cr != 0 else 0.0
+        fin_area = 0.5 * (cr + ct) * s
+        AR = 2 * s ** 2 / fin_area if fin_area > 0 else 0.0
+        beta_m = np.sqrt(abs(1.0 - mach ** 2)) if mach < 1 else np.sqrt(abs(mach ** 2 - 1))
+        denom = 2 + np.sqrt(4 + (AR * beta_m / max(np.cos(self.fin_sweep_angle), 1e-6)) ** 2)
+        cl_alpha = (2 * np.pi * AR / denom) * np.cos(self.fin_sweep_angle)
         cl = cl_alpha * alpha
-        
+
         # Moment coefficient using dynamic CP
         cp_current = self.get_dynamic_cp(mach, alpha)
-        static_margin = cp_current - self.center_of_mass_dry
+        if mass_props is None:
+            cg = self.center_of_mass_dry
+        else:
+            cg = mass_props['center_of_mass']
+        static_margin = cp_current - cg
         cm_alpha = -cl_alpha * static_margin / self.reference_diameter
         cm = cm_alpha * alpha
-        
+
+        # Side force coefficient
+        cy = cl_alpha * beta
+        cn = cl_alpha * alpha
+        cyaw = -cl_alpha * static_margin / self.reference_diameter * beta
+
         return {
             'cd': cd,
             'cl': cl,
             'cm': cm,
             'cp': cp_current,
-            'cn': cl,  # Normal force coefficient
-            'cy': 0.0,  # Side force coefficient (simplified)
+            'cn': cn,  # Normal force coefficient
+            'cy': cy,  # Side force coefficient
             'croll': 0.0,  # Roll moment coefficient
             'cpitch': cm,  # Pitch moment coefficient
-            'cyaw': cm   # Yaw moment coefficient
+            'cyaw': cyaw   # Yaw moment coefficient
         }
     
     def get_stability_margin(self, propellant_fraction_remaining):
         """Calculate static stability margin."""
-        mass_props = self.get_mass_properties(propellant_fraction_remaining)
-        return (self.cp_location - mass_props['center_of_mass']) / self.reference_diameter 
+        mass_props = self.get_mass_properties(propellant_fraction_remaining)        return (self.cp_location - mass_props['center_of_mass']) / self.reference_diameter 


### PR DESCRIPTION
## Summary
- add fin sweep and cant attributes to `Rocket`
- compute CP with sweep effects
- base aerodynamic moments on current CG and include sideslip
- apply wind effects on the rail and use new coeff API

## Testing
- `python -m py_compile rocket_simulation/*.py`
- `python rocket_simulation/example.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686d5597e9d483309e12f9a22f96215e