### PR TITLE
Enhance aerodynamic force calculations

### DIFF
--- a/rocket_simulation/simulator.py
+++ b/rocket_simulation/simulator.py
@@ -259,18 +259,14 @@ class FlightSimulator:
                 mach, alpha, beta, mass_props
             )
 
-            # Drag force opposite the direction of motion
-            drag_magnitude = q_dynamic * aero_coeffs['cd'] * self.rocket.reference_area
-            v_norm = np.linalg.norm(velocity_body)
-            if v_norm > 1e-6:
-                drag_direction = -velocity_body / v_norm
-                forces_body += drag_magnitude * drag_direction
+            # Aerodynamic forces in wind coordinates
+            drag = q_dynamic * aero_coeffs['cd'] * self.rocket.reference_area
+            lift = q_dynamic * aero_coeffs['cl'] * self.rocket.reference_area
+            side = q_dynamic * aero_coeffs['cy'] * self.rocket.reference_area
 
-            # Lift and side forces act along the body y/z axes
-            lift_force = q_dynamic * aero_coeffs['cl'] * self.rocket.reference_area
-            side_force = q_dynamic * aero_coeffs['cy'] * self.rocket.reference_area
-            forces_body[1] += side_force
-            forces_body[2] += lift_force
+            # Transform from wind axes to body axes
+            R_wind_to_body = wind_to_body_matrix(alpha, beta)
+            forces_body += R_wind_to_body @ np.array([-drag, -side, -lift])
 
             # Aerodynamic moments
             moments_body[0] += (

--- a/rocket_simulation/utils.py
+++ b/rocket_simulation/utils.py
@@ -128,6 +128,39 @@ def sideslip_angle(velocity_body):
     return np.arctan2(velocity_body[1], velocity_body[0])
 
 
+def wind_to_body_matrix(alpha, beta):
+    """Rotation matrix from wind axes to body axes.
+
+    Parameters
+    ----------
+    alpha : float
+        Angle of attack (rad).
+    beta : float
+        Sideslip angle (rad).
+
+    Returns
+    -------
+    numpy.ndarray
+        3x3 rotation matrix that transforms vectors from the wind reference
+        frame (x along the relative wind) to the body frame.  Positive ``alpha``
+        corresponds to a nose-up rotation and positive ``beta`` corresponds to a
+        nose-right rotation.
+    """
+
+    ca = np.cos(alpha)
+    sa = np.sin(alpha)
+    cb = np.cos(beta)
+    sb = np.sin(beta)
+
+    return np.array(
+        [
+            [ca * cb, -sb, sa * cb],
+            [ca * sb, cb, sa * sb],
+            [-sa, 0.0, ca],
+        ]
+    )
+
+
 def to_serializable(obj):
     """Recursively convert numpy types to Python types for JSON serialization."""
     if isinstance(obj, np.ndarray):


### PR DESCRIPTION
## Summary
- add `wind_to_body_matrix` helper for coordinate transforms
- compute aerodynamic forces in wind axes and rotate to body frame

## Testing
- `pytest` *(fails: no tests found)*
- `python rocket_simulation/example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d7162e0fc833082e71137a568913a